### PR TITLE
retain priority for path to fake module in `EasyBlock.load_fake_module`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1873,8 +1873,12 @@ class EasyBlock:
         fake_mod_path = self.make_module_step(fake=True)
         full_fake_mod_path = os.path.join(fake_mod_path, self.mod_subdir)
 
+        # indicate that path to fake module should get absolute priority
+        mod_paths = [(full_fake_mod_path, 10000)]
+
         # load fake module
-        self.load_module(purge=purge, extra_modules=extra_modules, mod_paths=[full_fake_mod_path], verbose=verbose)
+        self.load_module(purge=purge, extra_modules=extra_modules, mod_paths=mod_paths, verbose=verbose)
+
         return (fake_mod_path, env)
 
     def clean_up_fake_module(self, fake_mod_data):

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1111,9 +1111,15 @@ class ModulesTool:
 
         # extend $MODULEPATH if needed
         for mod_path in mod_paths:
+            priority = None
+            if isinstance(mod_path, tuple) and len(mod_path) == 2:
+                mod_path, priority = mod_path
+            elif not isinstance(mod_path, str):
+                raise EasyBuildError(f"Incorrect mod_paths entry encountered when loading module(s): {mod_path}")
+
             full_mod_path = os.path.join(install_path('mod'), build_option('suffix_modules_path'), mod_path)
             if os.path.exists(full_mod_path):
-                self.prepend_module_path(full_mod_path)
+                self.prepend_module_path(full_mod_path, priority=priority)
 
         loaded_modules = self.loaded_modules()
         for mod in modules:

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -480,6 +480,21 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(os.environ.get('EBROOTGCC'), None)
         self.assertNotEqual(loaded_modules[-1], 'GCC/6.4.0-2.28')
 
+        # test loading of module when particular module path has priority over others
+        if isinstance(self.modtool, Lmod):
+            mod_paths = [
+                os.path.join(self.test_prefix, 'one'),
+                (os.path.join(self.test_prefix, 'two'), 10000),
+                os.path.join(self.test_prefix, 'three'),
+            ]
+            for mod_path in mod_paths:
+                if isinstance(mod_path, tuple):
+                    mod_path = mod_path[0]
+                mod_file = os.path.join(mod_path, 'test', '1.2.3.lua')
+                write_file(mod_file, 'setenv("TEST_PARENT_DIR", "%s")' % os.path.basename(mod_path))
+            self.modtool.load(['test/1.2.3'], mod_paths=mod_paths)
+            self.assertEqual(os.getenv('TEST_PARENT_DIR'), 'two')
+
     def test_show(self):
         """Test for ModulesTool.show method."""
 


### PR DESCRIPTION
@xdelaruelle for https://github.com/easybuilders/easybuild-framework/pull/4991

We shouldn't just drop the `priority` part, that's important when using Lmod at least, since that undoes a fix that was added in:
* https://github.com/easybuilders/easybuild-framework/pull/2506
to fix:
* https://github.com/easybuilders/easybuild-framework/issues/2499