### PR TITLE
set `self.mod_paths` to `None` and call `check_module_path()` rather than calling `set_mod_paths()` after resetting environment in `ModulesTool.load`

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1106,8 +1106,10 @@ class ModulesTool:
                 raise EasyBuildError("Initial environment required when purging before loading, but not available")
 
             restore_env(init_env)
-            # sync mod_paths member with MODULEPATH environment variable
-            self.set_mod_paths()
+
+            # sync mod_paths class variable with $MODULEPATH environment variable after resetting environment
+            self.mod_paths = None
+            self.check_module_path()
 
         # extend $MODULEPATH if needed
         for mod_path in mod_paths:


### PR DESCRIPTION
@xdelaruelle for https://github.com/easybuilders/easybuild-framework/pull/4991